### PR TITLE
Fix integer subclass init and add tests

### DIFF
--- a/tests/test_integer.py
+++ b/tests/test_integer.py
@@ -1,0 +1,10 @@
+import unittest
+
+from toyotama.util.integer import UInt8, UChar, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64
+
+
+class IntegerInstantiationTestCase(unittest.TestCase):
+    def test_instantiation(self):
+        for cls in [UInt8, UChar, UInt16, UInt32, UInt64, Int8, Int16, Int32, Int64]:
+            cls(1)
+

--- a/toyotama/util/integer.py
+++ b/toyotama/util/integer.py
@@ -108,44 +108,44 @@ class Int:
 
 class UInt8(Int):
     def __init__(self, value):
-        super().__init__(self, value, bits=8, signed=False)
+        super().__init__(value, bits=8, signed=False)
 
 
 class UChar(Int):
     def __init__(self, value):
-        super().__init__(self, value, bits=8, signed=False)
+        super().__init__(value, bits=8, signed=False)
 
 
 class UInt16(Int):
     def __init__(self, value):
-        super().__init__(self, value, bits=16, signed=False)
+        super().__init__(value, bits=16, signed=False)
 
 
 class UInt32(Int):
     def __init__(self, value):
-        super().__init__(self, value, bits=32, signed=False)
+        super().__init__(value, bits=32, signed=False)
 
 
 class UInt64(Int):
     def __init__(self, value):
-        super().__init__(self, value, bits=64, signed=False)
+        super().__init__(value, bits=64, signed=False)
 
 
 class Int8(Int):
     def __init__(self, value):
-        super().__init__(self, value, bits=8, signed=True)
+        super().__init__(value, bits=8, signed=True)
 
 
 class Int16(Int):
     def __init__(self, value):
-        super().__init__(self, value, bits=16, signed=True)
+        super().__init__(value, bits=16, signed=True)
 
 
 class Int32(Int):
     def __init__(self, value):
-        super().__init__(self, value, bits=32, signed=True)
+        super().__init__(value, bits=32, signed=True)
 
 
 class Int64(Int):
     def __init__(self, value):
-        super().__init__(self, value, bits=64, signed=True)
+        super().__init__(value, bits=64, signed=True)


### PR DESCRIPTION
## Summary
- fix `super().__init__` usage in toyotama.util.integer
- add unit tests ensuring subclasses instantiate

## Testing
- `/usr/bin/python3 -m unittest discover` *(fails: ModuleNotFoundError: No module named 'Crypto', 'rich')*

------
https://chatgpt.com/codex/tasks/task_e_683fa52deac08333b28f511fb9c0687e