### PR TITLE
Remove debug print from BitStream

### DIFF
--- a/toyotama/util/bitstream.py
+++ b/toyotama/util/bitstream.py
@@ -20,7 +20,6 @@ class BitStream:
                 logger.warning("The value contains non-binary characters '%s'", value)
                 return
             self.bitstream = [int(c) ^ self.flip_mask for c in value]
-            print(self.bitstream)
 
     def __str__(self) -> str:
         s = "".join(str(b ^ self.flip_mask) for b in self.bitstream[: self.string_limit])


### PR DESCRIPTION
## Summary
- remove stray print from `BitStream.__init__`

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'Crypto')*

------
https://chatgpt.com/codex/tasks/task_e_683fa513c5988333b8abcf09b2eb7d7e